### PR TITLE
fix: add required permissions for semantic-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,11 @@ jobs:
     needs: [test, lint, build]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
## Summary
- Add explicit permissions to the release job in GitHub Actions workflow
- Fix EGITNOPERMISSION error that was preventing semantic-release from pushing tags and creating releases

## Changes
- Added `contents: write` permission to create releases and push tags
- Added `issues: write` permission for issue management  
- Added `pull-requests: write` permission for PR management
- Added `id-token: write` permission for OIDC authentication

## Test plan
- [ ] Merge this PR
- [ ] Verify that semantic-release workflow runs successfully on main branch
- [ ] Confirm that tags and releases are created properly

This resolves the GitHub Actions permission error that was blocking automated releases.