### PR TITLE
fix: add conventional-changelog-conventionalcommits dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,3 +185,4 @@ jobs:
           @semantic-release/changelog@6.0.0
           @semantic-release/git@10.0.0
           @semantic-release/exec@6.0.0
+          conventional-changelog-conventionalcommits@7.0.2


### PR DESCRIPTION
## Summary
- Add missing `conventional-changelog-conventionalcommits` package to semantic-release extra plugins
- Fix MODULE_NOT_FOUND error that was preventing semantic-release from analyzing commits

## Problem
The semantic-release workflow was failing with:
```
Error: Cannot find module 'conventional-changelog-conventionalcommits'
```

This happened because our `.releaserc.json` uses the `conventionalcommits` preset, but the required dependency wasn't installed in the GitHub Actions environment.

## Solution
- Added `conventional-changelog-conventionalcommits@7.0.2` to the `extra_plugins` list in the semantic-release action

## Test plan
- [ ] Merge this PR
- [ ] Verify that semantic-release can now analyze conventional commits successfully
- [ ] Confirm that releases are created properly

This resolves the missing dependency error blocking automated releases.