### PR TITLE
fix: make Go module cache conditional on go.sum existence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         go-version: ${{ env.GO_VERSION }}
 
     - name: Cache Go modules
+      if: hashFiles('**/go.sum') != ''
       uses: actions/cache@v4
       with:
         path: ~/go/pkg/mod
@@ -113,6 +114,7 @@ jobs:
         go-version: ${{ env.GO_VERSION }}
 
     - name: Cache Go modules
+      if: hashFiles('**/go.sum') != ''
       uses: actions/cache@v4
       with:
         path: ~/go/pkg/mod


### PR DESCRIPTION
## Summary
Fix cache-related warnings/failures that were potentially affecting semantic-release

## Problem
The CI workflow was showing cache failure warnings because:
- Cache step expects  file to exist  
- Our project uses only Go standard library (no external dependencies)
- No  file exists, causing cache restore failures
- These failures might be affecting the semantic-release job

## Solution
- Add conditional  to cache steps
- Only run cache when  file actually exists
- Eliminates warning/failure messages that could interfere with CI

## Expected Result
- Clean CI runs without cache warnings
- Semantic-release should now complete successfully  
- First release (1.0.0) should be created

This addresses the cache failures that may have been preventing semantic-release from completing.