### PR TITLE
Fix table width calculation for Unicode contributor names

### DIFF
--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"ganalyzer/pkg/types"
 )
@@ -112,8 +113,9 @@ func (f *Formatter) calculateNameWidth(contributors []*types.ContributorStats, c
 	nameWidth := minNameWidth
 	for _, contributor := range contributors {
 		name := f.formatContributorName(contributor, config)
-		if len(name) > nameWidth {
-			nameWidth = len(name)
+		nameLen := utf8.RuneCountInString(name)
+		if nameLen > nameWidth {
+			nameWidth = nameLen
 		}
 	}
 	return nameWidth + namePadding

--- a/internal/formatter/formatter_test.go
+++ b/internal/formatter/formatter_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"ganalyzer/pkg/types"
 )
@@ -150,6 +151,17 @@ func TestFormatter_EmptyStats(t *testing.T) {
 	output := buf.String()
 	if !strings.Contains(output, "No contributors found") {
 		t.Error("Expected 'No contributors found' message for empty stats")
+	}
+}
+
+func TestFormatter_CalculateNameWidthWithUnicode(t *testing.T) {
+	formatter := NewFormatter()
+	unicodeName := strings.Repeat("á", 21)
+	contributors := []*types.ContributorStats{{Name: unicodeName}}
+	width := formatter.calculateNameWidth(contributors, Config{})
+	expected := utf8.RuneCountInString(unicodeName) + namePadding
+	if width != expected {
+		t.Fatalf("expected width %d, got %d", expected, width)
 	}
 }
 


### PR DESCRIPTION
## Summary
- handle Unicode characters correctly when computing table column widths
- test that Unicode names produce expected table width

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a23150f524832d8ecff1d54a730985